### PR TITLE
Update clean script and add docker-compose for apsim-docs service

### DIFF
--- a/apsim-docs/docker-compose.yml
+++ b/apsim-docs/docker-compose.yml
@@ -1,0 +1,18 @@
+services:
+  apsim-docs:
+    image: apsiminitiative/apsim-docs:latest
+    pull_policy: always
+    container_name: apsim-docs
+    restart: unless-stopped
+    networks:
+      - apsim
+    ports:
+      - "8080:8080"
+    deploy:
+      resources:
+        limits:
+          cpus: '0.8'
+          memory: 6gb
+networks:
+  apsim:
+    external: true

--- a/clean.sh
+++ b/clean.sh
@@ -3,7 +3,8 @@
 # do a git clean and pull to get the latest revision
 # -e switch ignores particular files
 git clean -d -x -f\
- -e Infrastructure
+ -e Kapture \
+ -e BackupRestore
 git reset --hard
 git pull
 


### PR DESCRIPTION
working on #10

Enhance the clean script to ignore additional files and introduce a docker-compose configuration for the apsim-docs service.