### PR TITLE
Update .gitignore and add Kapture virtual host configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 httpd/.certs
 .prod
 .debug
+.env
 

--- a/clean.sh
+++ b/clean.sh
@@ -2,7 +2,7 @@
 
 # do a git clean and pull to get the latest revision
 # -e switch ignores particular files
-git clean -d -x -f\
+git clean -d -f\
  -e Kapture \
  -e BackupRestore
 git reset --hard

--- a/httpd/hosts/kapture.conf
+++ b/httpd/hosts/kapture.conf
@@ -1,0 +1,28 @@
+<VirtualHost *:80>
+	ServerName	kapture.apsim.info
+	ServerAdmin	dean.holzworth@csiro.au
+
+	ErrorLog        ${APACHE_LOG_DIR}/apsim-docs-error.log
+	CustomLog	${APACHE_LOG_DIR}/apsim-docs-access.log common
+
+	Redirect	"/" "https://kapture.apsim.info/"
+</VirtualHost>
+
+
+<VirtualHost *:443>
+	ServerName			kapture.apsim.info
+	ServerAdmin			dean.holzworth@csiro.au
+
+	ErrorLog			${APACHE_LOG_DIR}/apsim-docs-error.log
+	CustomLog			${APACHE_LOG_DIR}/apsim-docs-access.log common
+
+	# Proxy to kapture running in docker container on port 8080
+	ProxyPreserveHost	On
+
+	ProxyPassReverse        /    http://kapture:8080/
+	ProxyPass               /    http://kapture:8080/
+
+	SSLEngine On
+	SSLProxyEngine On
+
+</VirtualHost>


### PR DESCRIPTION
working on #10
Refine the clean script to avoid removing ignored files and enhance the .gitignore with important entries. Introduce a virtual host configuration for Kapture to manage HTTP and HTTPS traffic.