### PR TITLE
Refactor build contexts and remove vault service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,29 @@
 # apsim-web
 
 Web infrastructure around [APSIM](https://github.com/APSIMInitiative/ApsimX)
+
+## How to bring all services up and down
+
+* Most services can be deployed using the `./deploy.sh all` command directly under the apsim-web directory.
+* Most services do not require local images to be built. Httpd is the exception here which needs to be rebuilt to include additional `.conf` files.
+* most docker images used here can be found [here](https://hub.docker.com/u/apsiminitiative)
+
+### Vault
+
+This is a special case and cannot be deployed from the root docker-compose.yml file as the root level .env interferes with container settings causing it not to work. It will launch, however will not be functional.
+
+### Registration
+
+This image is built locally. Any updates will require the image to be rebuilt on the host machine.
+
+### All other services/containers
+
+All services other than vault can be launched via `./deploy.sh all`.
+
+### Adding new services
+
+To make the services available:
+
+* create a new `.conf` and place this under the hosts directory in the httpd project directory.
+* Rebuild the httpd image by using the command from the apsim-web directory `cd httpd && docker build -t httpd:apsim .`
+* then redeploy the apsim-web stack by using the command `./deploy.sh all`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,9 @@ services:
     pull_policy: always
     container_name: apsim-builds
     restart: unless-stopped
-    context: ./builds
+    build:
+      context: ./builds
+      dockerfile: ./builds/dockerfile
     profiles:
       - all
       - builds
@@ -53,6 +55,9 @@ services:
     container_name: httpd
     restart: unless-stopped
     context: ./httpd
+    build:
+      context: ./httpd
+      dockerfile: ./httpd/Dockerfile
     profiles:
       - all
       - httpd
@@ -69,7 +74,6 @@ services:
     pull_policy: always
     container_name: jenkins
     restart: unless-stopped
-    context: ./jenkins
     profiles:
       - all
       - jenkins
@@ -83,7 +87,6 @@ services:
     pull_policy: always
     container_name: postats-site
     restart: unless-stopped
-    context: ./postats
     profiles:
       - all
       - postats
@@ -101,7 +104,6 @@ services:
     pull_policy: always
     container_name: postats-db
     restart: unless-stopped
-    context: ./postats
     profiles:
       - all
       - postats
@@ -118,7 +120,9 @@ services:
     pull_policy: always
     container_name: registration-site
     restart: unless-stopped
-    context: ./registration
+    builds:
+      context: ./registration
+      dockerfile: ./registration/Dockerfile
     profiles:
       - all
       - registration
@@ -139,7 +143,6 @@ services:
     pull_policy: always
     container_name: registration-db
     restart: unless-stopped
-    context: ./registration
     profiles:
       - all
       - registration
@@ -149,31 +152,11 @@ services:
     volumes:
       - /data/registration/db:/var/lib/mysql
 
-  vault:
-    image: vaultwarden/server:latest
-    pull_policy: always
-    container_name: vault
-    restart: unless-stopped
-    context: ./vault
-    profiles:
-      - all
-      - vault
-    environment:
-      - WEBSOCKET_ENABLED=true  # Enable WebSocket notifications.
-      - ROCKET_PORT=8123
-      - SIGNUPS_ALLOWED=false
-      # - ADMIN_TOKEN=${ADMIN_TOKEN}
-    volumes:
-      - /data/vault:/data
-    networks:
-      - apsim
-
   postats2-site:
     image: apsiminitiative/postats:latest
     pull_policy: always
     container_name: postats2-site
     restart: unless-stopped
-    context: ./postats2
     profiles:
       - all
       - postats2
@@ -191,7 +174,6 @@ services:
     pull_policy: always
     container_name: postats2-db
     restart: unless-stopped
-    context: ./postats2
     profiles:
       - all
       - postats2
@@ -208,7 +190,6 @@ services:
     pull_policy: always
     container_name: apsim-docs
     restart: unless-stopped
-    context: ./apsim-docs
     profile:
       - all
       - apsim-docs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,9 +6,6 @@ services:
     pull_policy: always
     container_name: apsim-builds
     restart: unless-stopped
-    build:
-      context: ./builds
-      dockerfile: ./builds/dockerfile
     profiles:
       - all
       - builds
@@ -37,7 +34,6 @@ services:
     pull_policy: always
     container_name: builds-db
     restart: unless-stopped
-    context: ./builds
     profiles:
       - all
       - builds
@@ -54,7 +50,6 @@ services:
     pull_policy: always
     container_name: httpd
     restart: unless-stopped
-    context: ./httpd
     build:
       context: ./httpd
       dockerfile: ./httpd/Dockerfile
@@ -120,7 +115,7 @@ services:
     pull_policy: always
     container_name: registration-site
     restart: unless-stopped
-    builds:
+    build:
       context: ./registration
       dockerfile: ./registration/Dockerfile
     profiles:
@@ -190,7 +185,7 @@ services:
     pull_policy: always
     container_name: apsim-docs
     restart: unless-stopped
-    profile:
+    profiles:
       - all
       - apsim-docs
     networks:


### PR DESCRIPTION
working on #10 

Adjust build contexts for several services to ensure proper Dockerfile usage and remove the vault service to prevent inclusion of sensitive environment variables.