### PR TITLE
make all services start after apsim-docs

### DIFF
--- a/crontab
+++ b/crontab
@@ -1,0 +1,28 @@
+# Edit this file to introduce tasks to be run by cron.
+#
+# Each task to run has to be defined through a single line
+# indicating with different fields when the task will be run
+# and what command to run for the task
+#
+# To define the time you can provide concrete values for
+# minute (m), hour (h), day of month (dom), month (mon),
+# and day of week (dow) or use '*' in these fields (for 'any').
+#
+# Notice that tasks will be started based on the cron's system
+# daemon's notion of time and timezones.
+#
+# Output of the crontab jobs (including errors) is sent through
+# email to the user the crontab file belongs to (unless redirected).
+#
+# For example, you can run a backup of all your user accounts
+# at 5 a.m every week with:
+# 0 5 * * 1 tar -zcf /var/backups/home.tgz /home/
+#
+# For more information see the manual pages of crontab(5) and cron(8)
+#
+# m h  dom mon dow   command
+# This runs at 4:30 each night UTC time.
+
+0 17 * * * /home/webmaster/sources/apsim-web/deploy.sh down
+1 17 * * * /home/webmaster/sources/apsim-web/deploy.sh apsim-docs
+30 17 * * * /home/webmaster/sources/apsim-web/deploy.sh all

--- a/deploy.sh
+++ b/deploy.sh
@@ -18,6 +18,7 @@ set -euo pipefail  # stop on errors
 if [ $command == "down" ]; then
     echo "Bringing docker stack down"
     docker compose --profile all down --timeout 60
+    docker compose --profile apsim-docs down --timeout 60 
 elif [ $command == "apsim-docs" ]; then
     echo "Bringing docker stack apsim-docs up"
     docker compose --profile apsim-docs down --timeout 60

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -192,7 +192,6 @@ services:
     container_name: apsim-docs
     restart: unless-stopped
     profiles:
-      - all
       - apsim-docs
     networks:
       - apsim

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,7 @@ services:
     restart: unless-stopped
     build:
       context: ./httpd
-      dockerfile: ./httpd/Dockerfile
+      dockerfile: ./Dockerfile
     profiles:
       - all
       - httpd


### PR DESCRIPTION
resolves #43

- this is to make sure apsim-docs finishes document generation. It uses a lot of resources first