### PR TITLE
Add env vars to docker compose for postats2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -191,6 +191,9 @@ services:
       - postats2-db
     environment:
       - MARIADB_ROOT_PASSWORD=${MARIADB_ROOT_PASSWORD}
+      - AZURE_BATCH_ACCOUNT_URL=${AZURE_BATCH_ACCOUNT_URL}
+      - AZURE_BATCH_ACCOUNT_NAME=${AZURE_BATCH_ACCOUNT_NAME}
+      - AZURE_BATCH_ACCOUNT_KEY=${AZURE_BATCH_ACCOUNT_KEY}
     volumes:
       - /data/postats2/db:/var/lib/mysql
     networks:


### PR DESCRIPTION
resolves #49

This PR simply adds the required env vars to the service so the postats2 container will include them when built.