### PR TITLE
adds env to registration-db service to help with mariadb upgrade

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -149,6 +149,8 @@ services:
     pull_policy: always
     container_name: registration-db
     restart: unless-stopped
+    environment:
+      - MARIADB_AUTO_UPGRADE=true
     profiles:
       - dev
       - all


### PR DESCRIPTION
working on #55

This should help with the attempt to make mariadb upgrade correctly