### PR TITLE
Use .key file format again

### DIFF
--- a/httpd/Dockerfile
+++ b/httpd/Dockerfile
@@ -7,7 +7,7 @@ COPY ./hosts/*.conf /usr/local/apache2/conf/extra/httpd-vhosts.conf.d/
 # Copy certificates.
 COPY .certs/server.crt /usr/local/apache2/conf/server.crt
 COPY .certs/server-chain.crt /usr/local/apache2/conf/server-chain.crt
-COPY .certs/server.pem /usr/local/apache2/conf/server.pem
+COPY .certs/server.key /usr/local/apache2/conf/server.key
 
 # Copy in config file overrides.
 COPY httpd.conf /usr/local/apache2/conf/httpd.conf

--- a/httpd/httpd-ssl.conf
+++ b/httpd/httpd-ssl.conf
@@ -93,7 +93,7 @@ SSLSessionCache        "shmcb:/usr/local/apache2/logs/ssl_scache(512000)"
 SSLSessionCacheTimeout  300
 
 SSLCertificateFile /usr/local/apache2/conf/server.crt
-SSLCertificateKeyFile /usr/local/apache2/conf/server.pem
+SSLCertificateKeyFile /usr/local/apache2/conf/server.key
 SSLCertificateChainFile /usr/local/apache2/conf/server-chain.crt
 
 #   OCSP Stapling (requires OpenSSL 0.9.8h or later)


### PR DESCRIPTION
working on #63

pem format didn't play nice with Apache. Switching back to .key.