### PR TITLE
add docs for next time around for cert renewal

### DIFF
--- a/httpd/README.md
+++ b/httpd/README.md
@@ -14,3 +14,20 @@ docker build -t httpd:apsim .
 docker-compose down
 docker-compose up -d
 ```
+
+## Updating SSL/TLS certificates
+
+1. On the server, change into root user using `sudo -i`
+2. Use the command to generate a csr file: `openssl req -new -newkey rsa:2048 -nodes -keyout apsim.info.key -out apsim.info.csr`
+3. Provide the contents of the `.csr` file to your SSL certificate provider e.g. GoDaddy.
+4. Finish steps in certificate providers site until you get your .crt files. You'll need two.
+5. Move these to `httpd/.certs`.
+6. Move the apsim.info.key file to `httpd/.certs`.
+7. Rename these three files to match the names specified in `httpd-ssl.conf`.
+8. Redeploy the docker services using the deploy.sh script.
+9. Check that your web services can be accessed via https protocol.
+10. Done.
+
+### Common certificate generation issues
+
+- if openssl has trouble with missing libraries/packages. Simply reinstall on the server.


### PR DESCRIPTION
resolves #63

Adds documentation to help with renewal.
This will hopefully reduce the time needed in future to complete the process.