### PR TITLE
Mount markdown files

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -236,7 +236,7 @@ services:
     ports:
       - "8088:80"
     volumes:
-      - registration_api_db:/app/data
+      - ${REGISTRATION_SYSTEM_DB_PATH}:/app/data
     restart: unless-stopped
     networks:
       - apsim

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -200,6 +200,7 @@ services:
       - 5000:5000
     volumes:
       - /data/apsim-docs/:/app/apsim-docs-html
+      - /data/apsim-docs-md/:/app/apsim-docs-md
     environment:
       - ASPNETCORE_URLS=http://*:5000
 


### PR DESCRIPTION
resolves #88

This now adds additional markdown directory as a bind mount for the apsim-docs service.

This allows the apsim-docs service to serve up markdown files.