### PR TITLE
Allow forwarding of client info for registration system

### DIFF
--- a/httpd/hosts/registration.conf
+++ b/httpd/hosts/registration.conf
@@ -12,6 +12,7 @@
 
 	SSLEngine On
 	SSLProxyEngine On
+	ProxyAddHeaders On
 </VirtualHost>
 
 # Listen on port 80 (ie http) but redirect to 443 (https).
@@ -25,4 +26,5 @@
 	RewriteEngine		On
 	RewriteCond			%{SERVER_NAME} =registration.apsim.info
 	RewriteRule			^							https://%{SERVER_NAME}%{REQUEST_URI} [END,NE,R=permanent]
+	ProxyAddHeaders On
 </VirtualHost>


### PR DESCRIPTION
In order to capture country details for users, client information needs to be forwarded to the registration docker service.